### PR TITLE
Update deprecated wtf import

### DIFF
--- a/main/templates/tutorial/create.md
+++ b/main/templates/tutorial/create.md
@@ -12,10 +12,10 @@ and add the following code that will be responsible for validating the user's
 input.
 
 ```python
-from flask.ext import wtf
+import flask_wtf
 import wtforms
 
-class ContactUpdateForm(wtf.Form):
+class ContactUpdateForm(flask_wtf.FlaskForm):
   name = wtforms.StringField('Name', [wtforms.validators.required()])
   email = wtforms.StringField('Email', [wtforms.validators.optional(), wtforms.validators.email()])
   phone = wtforms.StringField('Phone', [wtforms.validators.optional()])


### PR DESCRIPTION
I think this will prevent two FlaskWTFDeprecationWarnings
- ../main/control/file.py:20: FlaskWTFDeprecationWarning: "flask_wtf.Form" has been renamed to "FlaskForm" and will be removed in 1.0.
- ../main/control/file.py:1: ExtDeprecationWarning: Importing flask.ext.wtf is deprecated, use flask_wtf instead.